### PR TITLE
Attempt to fix install on Bullseye: python-dev shouldnt be required?

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,7 @@ pkg_dependencies="python3-venv expect \
 apt-transport-https ca-certificates gnupg2 zlib1g-dev dumb-init gosu cron unzip curl \
 fontconfig fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-symbola fonts-noto fonts-freefont-ttf \
 wget curl chromium git ffmpeg youtube-dl ripgrep \
-build-essential python-dev python3-dev"
+build-essential python3-dev"
 
 nodejs_version=14
 


### PR DESCRIPTION
## Problem

Install fails on buster because of apt deps issues, probably because the app requires `python-dev` (implicitly python2), which conflicts with python3 etc

## Solution

Do not install python-dev, shouldnt be required because the app seems to be using python3

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
